### PR TITLE
patch to working  COM transport

### DIFF
--- a/lib/transports/AsciiTransport.js
+++ b/lib/transports/AsciiTransport.js
@@ -275,8 +275,12 @@ class AsciiTransport extends Transport
    */
   hasCompleteFrame(buffer)
   {
-    return buffer.readByte(buffer.length - 2) === ASCII_FRAME_CR
+    if (buffer.length >= 2)
+    {
+      return buffer.readByte(buffer.length - 2) === ASCII_FRAME_CR
       && buffer.readByte(buffer.length - 1) === ASCII_FRAME_LF;
+    }
+    return false;
   }
 
   /**

--- a/lib/transports/RtuTransport.js
+++ b/lib/transports/RtuTransport.js
@@ -79,7 +79,7 @@ class RtuTransport extends Transport
      * @private
      * @type {number}
      */
-    this.eofTimeout = options.eofTimeout > 0 ? options.eofTimeout : 0;
+    this.eofTimeout = options.eofTimeout > 0 ? options.eofTimeout : 10;
 
     /**
      * @private


### PR DESCRIPTION
rtu (default eoftimeout value updated to 10ms according to jsdoc) 
asci (avoid faulty index test when buffer length< 2)